### PR TITLE
Fix Logo Link

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,6 +100,7 @@ plugins:
   - mike
 
 extra:
+  homepage: https://queracomputing.github.io/bloqade-python/latest/
   version:
     provider: mike
   annotate:


### PR DESCRIPTION
Clicking the logo should now bring you to the proper Bloqade home page versus keeping you in the Tutorials section.