### PR TITLE
Standardize Plot Legends

### DIFF
--- a/docs/examples/example-1-floquet.py
+++ b/docs/examples/example-1-floquet.py
@@ -146,12 +146,12 @@ emulator_report = emu_batch.report()
 
 times = emulator_report.list_param("run_time")
 density = [1 - ele.mean() for ele in emulator_report.bitstrings()]
-plt.plot(times, density, color="#878787", marker=".", label="emulation")
+plt.plot(times, density, color="#878787", marker=".", label="Emulator")
 
 times = hardware_report.list_param("run_time")
 density = [1 - ele.mean() for ele in hardware_report.bitstrings()]
 
-plt.plot(times, density, color="#6437FF", linewidth=4, label="qpu")
+plt.plot(times, density, color="#6437FF", linewidth=4, label="QPU")
 plt.xlabel("Time ($\mu s$)")
 plt.ylabel("Rydberg population")
 plt.legend()

--- a/docs/examples/example-1-rabi.py
+++ b/docs/examples/example-1-rabi.py
@@ -162,12 +162,12 @@ emulator_report = emu_batch.report()
 
 times = emulator_report.list_param("run_time")
 density = [1 - ele.mean() for ele in emulator_report.bitstrings()]
-plt.plot(times, density, color="#878787", marker=".", label="Emuator")
+plt.plot(times, density, color="#878787", marker=".", label="Emulator")
 
 times = hardware_report.list_param("run_time")
 density = [1 - ele.mean() for ele in hardware_report.bitstrings()]
+plt.plot(times, density, color="#6437FF", linewidth=4, label="QPU")
 
-plt.plot(times, density, color="#6437FF", linewidth=4, label="Hardware")
 plt.xlabel("Time ($\mu s$)")
 plt.ylabel("Rydberg population")
 plt.legend()

--- a/docs/examples/example-1-ramsey.py
+++ b/docs/examples/example-1-ramsey.py
@@ -126,12 +126,12 @@ emulator_report = emu_batch.report()
 
 times = emulator_report.list_param("run_time")
 density = [1 - ele.mean() for ele in emulator_report.bitstrings()]
-plt.plot(times, density, color="#878787", marker=".", label="emulation")
+plt.plot(times, density, color="#878787", marker=".", label="Emulator")
 
 times = hardware_report.list_param("run_time")
 density = [1 - ele.mean() for ele in hardware_report.bitstrings()]
 
-plt.plot(times, density, color="#6437FF", linewidth=4, label="qpu")
+plt.plot(times, density, color="#6437FF", linewidth=4, label="QPU")
 plt.xlabel("Time ($\mu s$)")
 plt.ylabel("Rydberg population")
 plt.legend()

--- a/docs/examples/example-2-multi-qubit-blockaded.py
+++ b/docs/examples/example-2-multi-qubit-blockaded.py
@@ -168,9 +168,9 @@ fig, ax = plt.subplots()
 ax.set_xlabel("Time")
 ax.set_ylabel("Sum of Rydberg Densities")
 # emulation
-ax.plot(emu_run_times, emu_densities_summed, label="Emulation", color="#878787")
+ax.plot(emu_run_times, emu_densities_summed, label="Emulator", color="#878787")
 # hardware
-ax.plot(hw_run_times, hardware_densities_summed, label="Hardware", color="#6437FF")
+ax.plot(hw_run_times, hardware_densities_summed, label="QPU", color="#6437FF")
 ax.legend()
 ax.set_xlabel("Time ($\mu s$)")
 ax.set_ylabel("Sum of Rydberg Densities")

--- a/docs/examples/example-2-nonequilibrium-dynamics-blockade-radius.py
+++ b/docs/examples/example-2-nonequilibrium-dynamics-blockade-radius.py
@@ -170,7 +170,7 @@ for ax, rydberg_state, color in zip(axs, ["0", "1", "2"], emu_colors):
     (hw_line,) = ax.plot(
         emu_run_times,
         hw_rydberg_state_probabilities[rydberg_state],
-        label=rydberg_state + "-Rydberg",
+        label=rydberg_state + "-Rydberg QPU",
         color=color,
     )
     (emu_line,) = ax.plot(

--- a/docs/examples/example-2-two-qubit-adiabatic.py
+++ b/docs/examples/example-2-two-qubit-adiabatic.py
@@ -195,7 +195,7 @@ for rydberg_state, color in zip(["0", "1", "2"], emu_colors):
     (hw_line,) = ax.plot(
         emu_distances,
         hw_rydberg_state_probabilities[rydberg_state],
-        label=rydberg_state + "-Rydberg",
+        label=rydberg_state + "-Rydberg QPU",
         color=color,
     )
     (emu_line,) = ax.plot(

--- a/docs/examples/example-3-time-sweep.py
+++ b/docs/examples/example-3-time-sweep.py
@@ -53,7 +53,8 @@ if not os.path.isdir("data"):
     os.mkdir("data")
 
 # %% [markdown]
-# ## Program Definition We define a program where our geometry is a chain of 11 atoms
+# ## Program Definition 
+# We define a program where our geometry is a chain of 11 atoms
 # with a distance of 6.1 micrometers between atoms.
 
 # The pulse schedule presented here should be reminiscent of the Two Qubit Adiabatic
@@ -117,7 +118,8 @@ if not os.path.isfile(filename):
     save(future, filename)
 
 # %% [markdown]
-# ## Plotting the Results To make our lives easier we define a trivial function to
+# ## Plotting the Results 
+# To make our lives easier we define a trivial function to
 # extract the probability of the Z2 phase from each of the tasks generated from the
 # parameter sweep. The counts are obtained from the `report`of the batch object.
 
@@ -135,7 +137,8 @@ def get_z2_probabilities(report):
 
 
 # %% [markdown]
-# ## Extracting Counts And ProbabilitiesWe will now extract the counts and probabilities
+# ## Extracting Counts And Probabilities
+# We will now extract the counts and probabilities
 # from the emulator and hardware runs. We will then plot the results. First we load the
 # data from the files:
 
@@ -165,9 +168,8 @@ hardware_sweep_times = hardware_report.list_param("sweep_time")
 
 
 plt.plot(emu_sweep_times, emu_probabilities, label="Emulator", color="#878787")
-plt.plot(
-    hardware_sweep_times, hardware_probabilities, label="Hardware", color="#6437FF"
-)
+plt.plot(hardware_sweep_times, hardware_probabilities, label="QPU", color="#6437FF")
+
 plt.show()
 
 # %% [markdown]

--- a/docs/examples/example-4-quantum-scar-dynamics.py
+++ b/docs/examples/example-4-quantum-scar-dynamics.py
@@ -171,7 +171,7 @@ hw_run_times = hardware_report.list_param("run_time")
 hw_z2_prob = get_z2_probabilities(hardware_report)
 
 plt.plot(emu_run_times, emu_z2_prob, label="Emulator", color="#878787")
-plt.plot(hw_run_times, hw_z2_prob, label="Hardware", color="#6437FF")
+plt.plot(hw_run_times, hw_z2_prob, label="QPU", color="#6437FF")
 
 plt.legend()
 plt.xlabel("Time ($\mu s$)")


### PR DESCRIPTION
Use "Emulator" vs. "QPU" across ALL plots, also fixed a markdown formatting issue that caused the body text to bleed into the titles