### PR TITLE
Fix broken cell copy-paste

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,7 @@ plugins:
             docstring_options:
               ignore_init_summary: true
   - minify:
-      minify_html: true
+      minify_html: false
   - mkdocs-jupyter:
       include: ["*.py"] # only include scripts
       ignore: [


### PR DESCRIPTION
The `minify` plugin for MkDocs has a `minify-html` option that, when set to true, seems to break the ability to copy paste from the cells of our tutorial examples.

Users can still copy paste but it comes out as a single line without any formatting.

Setting `minify-html` to `false` restores the ability to copy-paste from cells with preserved formatting. 

Testing on my end has confirmed this is the case.