### PR TITLE
Add sidebar link to LGT example

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - Tutorial 8: examples/example-3-2d-ordered-state.py
     - Tutorial 9: examples/example-4-quantum-scar-dynamics.py
     - Tutorial 10: examples/example-5-MIS-UDG.py
+    - Tutorial 11: examples/example-6-lattice-gauge-theory.py
   - Reference: 'https://bloqade.quera.com/latest/reference/overview/'
   - Blog: 'https://queracomputing.github.io/bloqade-python/latest/blog/2023/'
   - License: 'https://github.com/QuEraComputing/bloqade-python/blob/main/LICENSE'


### PR DESCRIPTION
Previously the LGT example would show up in the main UI but not on the side menu. Reported and requested by @fanglifl 