### PR TITLE
[UnitaryHack] Improve quantum scar density plots

### DIFF
--- a/docs/examples/example-4-quantum-scar-dynamics.py
+++ b/docs/examples/example-4-quantum-scar-dynamics.py
@@ -40,6 +40,11 @@
 # to oscillate but because of the Blockade effect, the atoms will not be able to
 # transition to the Rydberg state. However, the atoms will still oscillate between the
 # ground and some other excited many-body states.
+#
+# The Z2 state is an alternating Rydberg-density pattern along the chain. Quantum scar
+# dynamics are visible as partial revivals of this pattern after the preparation ramp,
+# so the final section plots both the Z2-state probability and the site-resolved
+# Rydberg densities.
 
 
 # %% [markdown]
@@ -166,8 +171,25 @@ def get_z2_probabilities(report):
     return z2_probabilities
 
 
+def get_rydberg_densities(report):
+    return np.array([1 - bitstrings.mean(axis=0) for bitstrings in report.bitstrings()])
+
+
+def parameter_edges(values):
+    values = np.array([float(value) for value in values])
+    if len(values) == 1:
+        return np.array([values[0] - 0.5, values[0] + 0.5])
+
+    midpoints = (values[:-1] + values[1:]) / 2
+    first_edge = values[0] - (midpoints[0] - values[0])
+    last_edge = values[-1] + (values[-1] - midpoints[-1])
+    return np.concatenate(([first_edge], midpoints, [last_edge]))
+
+
 # %% [markdown]
-# We can now plot the results from the emulator and hardware. We see that the emulator
+# We can now plot the results from the emulator and hardware. Peaks in the Z2-state
+# probability mark times where the alternating density pattern partially revives after
+# the drive begins.
 
 # %%
 
@@ -187,4 +209,46 @@ plt.plot(hw_run_times, hw_z2_prob, label="QPU", color="#6437FF")
 plt.legend()
 plt.xlabel("Time ($\mu s$)")
 plt.ylabel("Z2-state Probability")
+plt.show()
+
+# %% [markdown]
+# The Z2-state probability compresses the entire chain into a single number. To see
+# where the revivals come from, we can also plot the Rydberg density at each atom site.
+# The early-time preparation region builds the alternating Z2 pattern, while the later
+# scar dynamics show how that pattern dephases and partially returns over time.
+
+# %%
+emu_densities = get_rydberg_densities(emu_report)
+hw_densities = get_rydberg_densities(hardware_report)
+
+site_edges = np.arange(n_atoms + 1) - 0.5
+
+fig, axes = plt.subplots(
+    1,
+    2,
+    figsize=(12, 4),
+    sharey=True,
+    constrained_layout=True,
+)
+
+for ax, densities, times, title in zip(
+    axes,
+    (emu_densities, hw_densities),
+    (emu_run_times, hw_run_times),
+    ("Emulator", "QPU"),
+):
+    mesh = ax.pcolormesh(
+        parameter_edges(times),
+        site_edges,
+        densities.T,
+        shading="auto",
+        vmin=0,
+        vmax=1,
+        cmap="viridis",
+    )
+    ax.set_title(f"{title} site-resolved densities")
+    ax.set_xlabel("Time ($\mu s$)")
+
+axes[0].set_ylabel("Atom site")
+fig.colorbar(mesh, ax=axes, label="Rydberg density")
 plt.show()


### PR DESCRIPTION
## Summary

- Expand the quantum scar tutorial text to explain why the Z2 revival is connected to an alternating Rydberg-density pattern.
- Add helpers for site-resolved Rydberg densities and non-uniform run-time bin edges.
- Add side-by-side emulator/QPU heatmaps showing per-atom Rydberg density across the preparation and scar-dynamics sweep.

## Bounty / issue

This improves one tutorial example for QuEraComputing/bloqade-analog#876, which requests more physics explanation and plots for tutorial examples, including density-style plots.

## Transparency

AI assistance was used to prepare this PR. I reviewed the generated diff, kept the change scoped to one tutorial, and ran the checks below locally.

## Validation

- `python3 -m py_compile docs/examples/example-4-quantum-scar-dynamics.py`
- `python3 -m ruff check docs/examples/example-4-quantum-scar-dynamics.py`
- `python3 -m black --check docs/examples/example-4-quantum-scar-dynamics.py`
- `git diff --check`
- `MPLBACKEND=Agg python3 <representative heatmap smoke test>` -> `heatmap smoke ok (11, 191) 192 12`

I did not run the full tutorial end-to-end in this container because the local environment does not have `bloqade` installed (`ModuleNotFoundError: No module named 'bloqade'`).
