### PR TITLE
[UnitaryHack] Improve 2D ordered-state tutorial plots

### DIFF
--- a/docs/examples/example-3-2d-ordered-state.py
+++ b/docs/examples/example-3-2d-ordered-state.py
@@ -35,8 +35,12 @@
 # %% [markdown]
 # # 2D State Preparation
 # ## Introduction
-# In this example we show how to create the Striated Phase
-# on a 2D chain of atoms.
+# In this example we show how to create the Striated Phase on a small 2D square
+# lattice of atoms. The protocol is similar in spirit to the 1D Z2 preparation:
+# start with negative detuning, turn on the Rabi coupling, sweep to positive
+# detuning, and let the Rydberg blockade select an ordered pattern. In two
+# dimensions the ordering is easier to understand when we look at the spatial
+# density pattern rather than only at raw bitstring counts.
 
 # %% [markdown]
 # You might notice that the tools we need to import are
@@ -47,6 +51,8 @@
 # %%
 import os
 
+import numpy as np
+import matplotlib.pyplot as plt
 from bokeh.io import output_notebook
 from bloqade.analog import load, save
 from bloqade.analog.atom_arrangement import Square
@@ -79,6 +85,61 @@ prog = (
 )
 
 batch = prog.assign(delta_end=42.66, sweep_time=2.4)
+
+# %% [markdown]
+# Before submitting the program, it is useful to preview both the geometry and the
+# pulse schedule. The nearest-neighbor spacing is chosen so that blockade effects
+# compete strongly with the positive final detuning, while the square geometry lets
+# us look for row- or column-like striations in the measured Rydberg density.
+
+# %%
+site_x, site_y = np.meshgrid(
+    np.arange(L) * lattice_spacing,
+    np.arange(L) * lattice_spacing,
+)
+site_indices = np.arange(L * L)
+
+fig, ax = plt.subplots(figsize=(4.5, 4))
+ax.scatter(site_x.ravel(), site_y.ravel(), s=160, color="#6437FF")
+for site_index, x_coord, y_coord in zip(site_indices, site_x.ravel(), site_y.ravel()):
+    ax.annotate(
+        str(site_index),
+        (x_coord, y_coord),
+        ha="center",
+        va="center",
+        color="white",
+        fontsize=9,
+    )
+ax.set_aspect("equal")
+ax.set_xlabel(r"x ($\mu m$)")
+ax.set_ylabel(r"y ($\mu m$)")
+ax.set_title("3 x 3 square lattice")
+plt.show()
+
+# %%
+preview_times = np.concatenate([[0.0], np.cumsum([0.8, 2.4, 0.8])])
+
+fig, ax = plt.subplots(figsize=(7, 4))
+ax.plot(
+    preview_times,
+    rabi_amplitude_values,
+    marker=".",
+    color="#6437FF",
+    label="Rabi amplitude",
+)
+ax.plot(
+    preview_times,
+    [-16.33, -16.33, 42.66, 42.66],
+    marker=".",
+    color="#C2477F",
+    label="Detuning",
+)
+ax.axhline(0, color="#878787", linestyle="--", linewidth=1)
+ax.set_xlabel(r"time ($\mu s$)")
+ax.set_ylabel(r"angular frequency (rad/$\mu s$)")
+ax.set_title("2D striated-state preparation pulse")
+ax.legend()
+plt.show()
 
 # %% [markdown]
 # ## Submitting to Emulator and Hardware
@@ -137,19 +198,106 @@ hardware_batch = load(hw_filename)
 # geometry with just the following:
 
 # %%
-emu_batch.report().show()
+emu_report = emu_batch.report()
+hardware_report = hardware_batch.report()
+
+emu_report.show()
 
 # %% [markdown]
 # Just as before, we let Bloqade generate a `report` which contains all the results in
 # easy to digest format but we invoke the `.show()` method of our report which us
 # easily get an idea of the results of our experiment with interactive plots.
 
-# The plot that mos interests us is the one on the right under the "Rydberg Density" section.
+# The plot that most interests us is the one on the right under the "Rydberg Density" section.
 
 # %%
-hardware_batch.report().show()
+hardware_report.show()
 
 # %% [markdown]
 # Considering Bloqade's goal of a uniform visualization pipeline, we can get the same
 # ability for results from hardware. Note that we can confirm the program does what it's
 # supposed to as results from emulation agree with those from hardware quite well.
+
+# %% [markdown]
+# The interactive reports above are convenient, but for a tutorial it also helps to
+# place the emulator and hardware densities on the same color scale. The heatmaps
+# below reshape the site-resolved Rydberg densities back onto the 3 x 3 lattice and
+# add a QPU-minus-emulator residual panel so the agreement is visible at a glance.
+
+
+# %%
+def density_grid(report):
+    densities = np.asarray(report.rydberg_densities(), dtype=float).reshape(-1)
+    if densities.size != L * L:
+        raise ValueError(f"Expected {L * L} densities, received {densities.size}")
+    return densities.reshape(L, L)
+
+
+emu_density_grid = density_grid(emu_report)
+hardware_density_grid = density_grid(hardware_report)
+density_residual = hardware_density_grid - emu_density_grid
+residual_limit = float(np.max(np.abs(density_residual)))
+if residual_limit == 0:
+    residual_limit = 1e-9
+
+fig, axes = plt.subplots(1, 3, figsize=(11, 3.8), layout="constrained")
+for ax, density_grid_values, title in [
+    (axes[0], emu_density_grid, "Emulator"),
+    (axes[1], hardware_density_grid, "Aquila QPU"),
+]:
+    image = ax.imshow(density_grid_values, origin="lower", vmin=0, vmax=1, cmap="magma")
+    ax.set_title(title)
+    ax.set_xticks(np.arange(L))
+    ax.set_yticks(np.arange(L))
+    ax.set_xlabel("lattice column")
+axes[0].set_ylabel("lattice row")
+fig.colorbar(image, ax=axes[:2], shrink=0.85, label="Rydberg density")
+
+residual_image = axes[2].imshow(
+    density_residual,
+    origin="lower",
+    vmin=-residual_limit,
+    vmax=residual_limit,
+    cmap="coolwarm",
+)
+axes[2].set_title("QPU - emulator")
+axes[2].set_xticks(np.arange(L))
+axes[2].set_yticks(np.arange(L))
+axes[2].set_xlabel("lattice column")
+fig.colorbar(residual_image, ax=axes[2], shrink=0.85, label="Density difference")
+plt.show()
+
+# %% [markdown]
+# We can also compress the density map into row and column averages. This provides a
+# quick diagnostic for whether the ordered state is forming a striated pattern along
+# one lattice direction and whether the same qualitative contrast appears in the
+# hardware data.
+
+# %%
+fig, axes = plt.subplots(1, 2, figsize=(10, 3.5), sharey=True, layout="constrained")
+for ax, reducer, title in [
+    (axes[0], lambda grid: grid.mean(axis=1), "Row-averaged density"),
+    (axes[1], lambda grid: grid.mean(axis=0), "Column-averaged density"),
+]:
+    positions = np.arange(L)
+    width = 0.36
+    ax.bar(
+        positions - width / 2,
+        reducer(emu_density_grid),
+        width,
+        color="#878787",
+        label="Emulator",
+    )
+    ax.bar(
+        positions + width / 2,
+        reducer(hardware_density_grid),
+        width,
+        color="#6437FF",
+        label="QPU",
+    )
+    ax.set_xticks(positions)
+    ax.set_xlabel("lattice index")
+    ax.set_title(title)
+axes[0].set_ylabel("mean Rydberg density")
+axes[1].legend()
+plt.show()


### PR DESCRIPTION
## Summary

- Expand the 2D ordered-state tutorial introduction to explain the blockade-driven striated-density goal.
- Add a 3 x 3 lattice geometry preview and representative pulse-schedule plot before execution.
- Add emulator/QPU density heatmaps, a QPU-minus-emulator residual panel, and row/column average-density summaries.

## Bounty / issue

This improves `docs/examples/example-3-2d-ordered-state.py` for QuEraComputing/bloqade-analog#876, which offers $20 per tutorial example improved with more physics explanation and plots.

## Validation

- `python3 -m py_compile docs/examples/example-3-2d-ordered-state.py`
- `git diff --check`
- `uv run ruff format --check docs/examples/example-3-2d-ordered-state.py`
- `uv run ruff check docs/examples/example-3-2d-ordered-state.py`
- `MPLBACKEND=Agg uv run --group doc python ../examples/example-3-2d-ordered-state.py` from `docs/assets`
